### PR TITLE
Attachment of ContextStamp to message bus envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The `RequestTransformer` will look for a constructor argument that has the type 
 If the command / DTO contains no constructor, it is assumed that the command requires no resource object.
 
 If the resource object is required by as a public property this should be set after the message was dispatched to the bus.
+The Api Platform `ContextStamp` is created and added to the envelope like it would originate from Api Platform itself.
 
 This bundle uses the default Symfony serializer (created by the framework) for the denormalization.
 Therefore, this process is limited to the capabilities of the Symfony serializer(s).

--- a/src/Context/ApiPlatformContext.php
+++ b/src/Context/ApiPlatformContext.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ApiPlatformUpdateActionsBundle\Context;
+
+use ApiPlatform\Core\Bridge\Symfony\Messenger\ContextStamp;
+use ITB\ApiPlatformUpdateActionsBundle\Context\ApiPlatformContextException\ObjectToPopulateMissingException;
+use ITB\ApiPlatformUpdateActionsBundle\Context\ApiPlatformContextException\ObjectToPopulateNotAnObjectException;
+use ITB\ApiPlatformUpdateActionsBundle\Context\ApiPlatformContextException\ResourceClassMissingException;
+use ITB\ApiPlatformUpdateActionsBundle\Context\ApiPlatformContextException\ResourceClassNotAStringException;
+use ITB\ApiPlatformUpdateActionsBundle\Exception\RuntimeExceptionInterface;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+
+final class ApiPlatformContext
+{
+    private const RESOURCE_OBJECT_KEY = AbstractNormalizer::OBJECT_TO_POPULATE;
+
+    /** @var string $resourceClass */
+    private string $resourceClass;
+    /** @var object $resourceObject */
+    private object $resourceObject;
+
+    /**
+     * @param array<string, mixed> $context
+     * @throws RuntimeExceptionInterface
+     */
+    public function __construct(private array $context)
+    {
+        if (!array_key_exists('resource_class', $this->context)) {
+            throw ResourceClassMissingException::create();
+        }
+        if (!is_string($this->context['resource_class'])) {
+            throw ResourceClassNotAStringException::create();
+        }
+        $this->resourceClass = $this->context['resource_class'];
+
+        if (!array_key_exists(self::RESOURCE_OBJECT_KEY, $this->context)) {
+            throw ObjectToPopulateMissingException::create();
+        }
+        if (!is_object($this->context[self::RESOURCE_OBJECT_KEY])) {
+            throw ObjectToPopulateNotAnObjectException::create();
+        }
+        $this->resourceObject = $this->context[self::RESOURCE_OBJECT_KEY];
+    }
+
+    /**
+     * @return string
+     */
+    public function getResourceClass(): string
+    {
+        return $this->resourceClass;
+    }
+
+    /**
+     * @return object
+     */
+    public function getResourceObject(): object
+    {
+        return $this->resourceObject;
+    }
+
+    /**
+     * @return ContextStamp
+     */
+    public function toContextStamp(): ContextStamp
+    {
+        return new ContextStamp($this->context);
+    }
+}

--- a/src/Context/ApiPlatformContextException/ObjectToPopulateMissingException.php
+++ b/src/Context/ApiPlatformContextException/ObjectToPopulateMissingException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ITB\ApiPlatformUpdateActionsBundle\Request\RequestTransformerException;
+namespace ITB\ApiPlatformUpdateActionsBundle\Context\ApiPlatformContextException;
 
 use Exception;
 use ITB\ApiPlatformUpdateActionsBundle\Exception\RuntimeExceptionInterface;

--- a/src/Context/ApiPlatformContextException/ObjectToPopulateNotAnObjectException.php
+++ b/src/Context/ApiPlatformContextException/ObjectToPopulateNotAnObjectException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ITB\ApiPlatformUpdateActionsBundle\Request\RequestTransformerException;
+namespace ITB\ApiPlatformUpdateActionsBundle\Context\ApiPlatformContextException;
 
 use Exception;
 use ITB\ApiPlatformUpdateActionsBundle\Exception\RuntimeExceptionInterface;

--- a/src/Context/ApiPlatformContextException/ResourceClassMissingException.php
+++ b/src/Context/ApiPlatformContextException/ResourceClassMissingException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ITB\ApiPlatformUpdateActionsBundle\Request\RequestTransformerException;
+namespace ITB\ApiPlatformUpdateActionsBundle\Context\ApiPlatformContextException;
 
 use Exception;
 use ITB\ApiPlatformUpdateActionsBundle\Exception\RuntimeExceptionInterface;

--- a/src/Context/ApiPlatformContextException/ResourceClassNotAStringException.php
+++ b/src/Context/ApiPlatformContextException/ResourceClassNotAStringException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ITB\ApiPlatformUpdateActionsBundle\Request\RequestTransformerException;
+namespace ITB\ApiPlatformUpdateActionsBundle\Context\ApiPlatformContextException;
 
 use Exception;
 use ITB\ApiPlatformUpdateActionsBundle\Exception\RuntimeExceptionInterface;

--- a/src/Controller/ControllerException/RequestApiPlatformContextIsNullException.php
+++ b/src/Controller/ControllerException/RequestApiPlatformContextIsNullException.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ApiPlatformUpdateActionsBundle\Controller\ControllerException;
+
+use Exception;
+use ITB\ApiPlatformUpdateActionsBundle\Exception\RuntimeExceptionInterface;
+use ITB\ApiPlatformUpdateActionsBundle\Request\RequestTransformer;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Throwable;
+
+final class RequestApiPlatformContextIsNullException extends Exception implements RuntimeExceptionInterface
+{
+    /**
+     * @param string $message
+     * @param mixed $data
+     */
+    public function __construct(string $message, private mixed $data)
+    {
+        parent::__construct($message, 0, null);
+    }
+
+    /**
+     * @param mixed $data
+     * @return RequestApiPlatformContextIsNullException
+     */
+    public static function create(mixed $data): RequestApiPlatformContextIsNullException
+    {
+        return new self(
+            sprintf(
+                'The api platform context property of the request is null. The property should be set in the %s class.',
+                RequestTransformer::class
+            ),
+            $data
+        );
+    }
+
+    /**
+     * @return Throwable
+     */
+    public function createApiPlatformCompatibleException(): Throwable
+    {
+        return NotNormalizableValueException::createForUnexpectedDataType(
+            $this->message,
+            $this->data,
+            [],
+            useMessageForUser: false,
+            previous: $this
+        );
+    }
+}

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ITB\ApiPlatformUpdateActionsBundle\Request;
 
+use ITB\ApiPlatformUpdateActionsBundle\Context\ApiPlatformContext;
 use ITB\ApiPlatformUpdateActionsBundle\Validation\UpdateRequest;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
@@ -16,9 +17,14 @@ final class Request
      * @param string $action
      * @param array<string, mixed> $payload
      * @param string|null $resource
+     * @param ApiPlatformContext|null $apiPlatformContext
      */
-    public function __construct(public string $action, public array $payload, public ?string $resource = null)
-    {
+    public function __construct(
+        public string $action,
+        public array $payload,
+        public ?string $resource = null,
+        public ?ApiPlatformContext $apiPlatformContext = null
+    ) {
     }
 
     /**


### PR DESCRIPTION
API Platform adds a ContextStamp to the envelope if the resulting object is dispatched via message bus. The stamp wraps the deserializtion context.

This stamp is created by this bundle as well and will also be attached to the envelope when the command / DTO is dispatched. With this stamp, handler and middlewares can access information from the deserializtion context.