### PR TITLE
Definition of actions via bundle configuration and attributes

### DIFF
--- a/src/Action/ActionCollection.php
+++ b/src/Action/ActionCollection.php
@@ -6,6 +6,7 @@ namespace ITB\ApiPlatformResourceActionsBundle\Action;
 
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
 use ITB\ApiPlatformResourceActionsBundle\Action\ActionCollectionException\ActionForResourceNotFound;
+use ITB\ApiPlatformResourceActionsBundle\Definition\ResourceActionDefinitionCollection;
 use ITB\ApiPlatformResourceActionsBundle\Exception\CompileTimeExceptionInterface;
 use ITB\ApiPlatformResourceActionsBundle\Exception\RuntimeExceptionInterface;
 
@@ -15,22 +16,20 @@ final class ActionCollection
     private array $actions = [];
 
     /**
-     * @param array<int, array{
-     *     'resource': string,
-     *     'action': string,
-     *     'commandClass': class-string,
-     *     'description': string|null
-     * }> $actionsData
+     * @param ResourceActionDefinitionCollection $resourceActionDefinitionCollection
+     * @param ResourceMetadataFactoryInterface $resourceMetadataFactory
      * @throws CompileTimeExceptionInterface
      */
-    public function __construct(array $actionsData, ResourceMetadataFactoryInterface $resourceMetadataFactory)
-    {
-        foreach ($actionsData as $actionData) {
+    public function __construct(
+        ResourceActionDefinitionCollection $resourceActionDefinitionCollection,
+        ResourceMetadataFactoryInterface $resourceMetadataFactory
+    ) {
+        foreach ($resourceActionDefinitionCollection->getResourceActionDefinitions() as $resourceActionDefinition) {
             $action = new Action(
-                $actionData['action'],
-                $actionData['resource'],
-                $actionData['commandClass'],
-                $actionData['description'],
+                $resourceActionDefinition->action,
+                $resourceActionDefinition->resource,
+                $resourceActionDefinition->command,
+                $resourceActionDefinition->description,
                 $resourceMetadataFactory
             );
 

--- a/src/Action/ResourceAction.php
+++ b/src/Action/ResourceAction.php
@@ -6,22 +6,22 @@ namespace ITB\ApiPlatformResourceActionsBundle\Action;
 
 use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
-use ITB\ApiPlatformResourceActionsBundle\Action\ActionException\CommandBlankException;
-use ITB\ApiPlatformResourceActionsBundle\Action\ActionException\CommandNotAClassException;
-use ITB\ApiPlatformResourceActionsBundle\Action\ActionException\DescriptionBlankException;
-use ITB\ApiPlatformResourceActionsBundle\Action\ActionException\NameBlankException;
-use ITB\ApiPlatformResourceActionsBundle\Action\ActionException\NoOperationConfiguredForActionException;
-use ITB\ApiPlatformResourceActionsBundle\Action\ActionException\ResourceBlankException;
-use ITB\ApiPlatformResourceActionsBundle\Action\ActionException\ResourceHasNoShortNameException;
-use ITB\ApiPlatformResourceActionsBundle\Action\ActionException\ResourceNotRegisteredException;
+use ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionException\CommandBlankException;
+use ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionException\CommandNotAClassException;
+use ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionException\DescriptionBlankException;
+use ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionException\NameBlankException;
+use ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionException\NoOperationConfiguredForActionException;
+use ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionException\ResourceBlankException;
+use ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionException\ResourceHasNoShortNameException;
+use ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionException\ResourceNotRegisteredException;
 use ITB\ApiPlatformResourceActionsBundle\Controller\Controller;
 use ITB\ApiPlatformResourceActionsBundle\Exception\CompileTimeExceptionInterface;
 use ITB\ApiPlatformResourceActionsBundle\Request\Request;
 
-final class Action
+final class ResourceAction
 {
-    /** @var ActionCommandMetadata $commandMetadata */
-    private ActionCommandMetadata $commandMetadata;
+    /** @var ResourceActionCommandMetadata $commandMetadata */
+    private ResourceActionCommandMetadata $commandMetadata;
 
     /** @var string $resourceName */
     private string $resourceName;
@@ -60,7 +60,7 @@ final class Action
             throw CommandNotAClassException::create($this->commandClass);
         }
 
-        $this->commandMetadata = new ActionCommandMetadata($this->commandClass);
+        $this->commandMetadata = new ResourceActionCommandMetadata($this->commandClass);
 
         if ('' === $this->description) {
             throw DescriptionBlankException::create();
@@ -142,9 +142,9 @@ final class Action
     }
 
     /**
-     * @return ActionCommandMetadata
+     * @return ResourceActionCommandMetadata
      */
-    public function getCommandMetadata(): ActionCommandMetadata
+    public function getCommandMetadata(): ResourceActionCommandMetadata
     {
         return $this->commandMetadata;
     }

--- a/src/Action/ResourceActionCollection.php
+++ b/src/Action/ResourceActionCollection.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace ITB\ApiPlatformResourceActionsBundle\Action;
 
 use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
-use ITB\ApiPlatformResourceActionsBundle\Action\ActionCollectionException\ActionForResourceNotFound;
+use ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionCollectionException\ActionForResourceNotFound;
 use ITB\ApiPlatformResourceActionsBundle\Definition\ResourceActionDefinitionCollection;
 use ITB\ApiPlatformResourceActionsBundle\Exception\CompileTimeExceptionInterface;
 use ITB\ApiPlatformResourceActionsBundle\Exception\RuntimeExceptionInterface;
 
-final class ActionCollection
+final class ResourceActionCollection
 {
-    /** @var array<string, Action> */
+    /** @var array<string, ResourceAction> */
     private array $actions = [];
 
     /**
@@ -25,7 +25,7 @@ final class ActionCollection
         ResourceMetadataFactoryInterface $resourceMetadataFactory
     ) {
         foreach ($resourceActionDefinitionCollection->getResourceActionDefinitions() as $resourceActionDefinition) {
-            $action = new Action(
+            $action = new ResourceAction(
                 $resourceActionDefinition->action,
                 $resourceActionDefinition->resource,
                 $resourceActionDefinition->command,
@@ -40,10 +40,10 @@ final class ActionCollection
     /**
      * @param string $resourceClass
      * @param string $actionName
-     * @return Action
+     * @return ResourceAction
      * @throws RuntimeExceptionInterface
      */
-    public function getAction(string $resourceClass, string $actionName): Action
+    public function getAction(string $resourceClass, string $actionName): ResourceAction
     {
         if (!array_key_exists($resourceClass . $actionName, $this->actions)) {
             throw ActionForResourceNotFound::create($resourceClass, $actionName);
@@ -53,7 +53,7 @@ final class ActionCollection
     }
 
     /**
-     * @return Action[]
+     * @return ResourceAction[]
      */
     public function getActions(): array
     {
@@ -62,12 +62,12 @@ final class ActionCollection
 
     /**
      * @param string $resource
-     * @return Action[]
+     * @return ResourceAction[]
      */
     public function getActionsForResource(string $resource): array
     {
         return array_values(
-            array_filter($this->actions, static function (Action $action) use ($resource): bool {
+            array_filter($this->actions, static function (ResourceAction $action) use ($resource): bool {
                 return $resource === $action->getResource();
             })
         );

--- a/src/Action/ResourceActionCollectionException/ActionForResourceNotFound.php
+++ b/src/Action/ResourceActionCollectionException/ActionForResourceNotFound.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ITB\ApiPlatformResourceActionsBundle\Action\ActionCollectionException;
+namespace ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionCollectionException;
 
 use Exception;
 use ITB\ApiPlatformResourceActionsBundle\Exception\RuntimeExceptionInterface;

--- a/src/Action/ResourceActionCommandMetadata.php
+++ b/src/Action/ResourceActionCommandMetadata.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace ITB\ApiPlatformResourceActionsBundle\Action;
 
-use ITB\ApiPlatformResourceActionsBundle\Action\ActionException\CommandConstructorParameterRetrievalFailedException;
-use ITB\ApiPlatformResourceActionsBundle\Action\ActionException\CommandNotAClassException;
+use ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionException\CommandConstructorParameterRetrievalFailedException;
+use ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionException\CommandNotAClassException;
 use ITB\ApiPlatformResourceActionsBundle\Exception\CompileTimeExceptionInterface;
 use ITB\ApiPlatformResourceActionsBundle\Exception\RuntimeExceptionInterface;
 use ITB\ReflectionConstructor\ReflectionConstructor;
@@ -13,7 +13,7 @@ use ReflectionClass;
 use ReflectionException;
 use ReflectionParameter;
 
-final class ActionCommandMetadata
+final class ResourceActionCommandMetadata
 {
     /** @var ReflectionClass $reflectionClass */
     /** @phpstan-ignore-next-line */

--- a/src/Action/ResourceActionException/CommandBlankException.php
+++ b/src/Action/ResourceActionException/CommandBlankException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ITB\ApiPlatformResourceActionsBundle\Action\ActionException;
+namespace ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionException;
 
 use Exception;
 use ITB\ApiPlatformResourceActionsBundle\Exception\CompileTimeExceptionInterface;

--- a/src/Action/ResourceActionException/CommandConstructorParameterRetrievalFailedException.php
+++ b/src/Action/ResourceActionException/CommandConstructorParameterRetrievalFailedException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ITB\ApiPlatformResourceActionsBundle\Action\ActionException;
+namespace ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionException;
 
 use Exception;
 use ITB\ApiPlatformResourceActionsBundle\Exception\RuntimeExceptionInterface;

--- a/src/Action/ResourceActionException/CommandHasNoConstructorException.php
+++ b/src/Action/ResourceActionException/CommandHasNoConstructorException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ITB\ApiPlatformResourceActionsBundle\Action\ActionException;
+namespace ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionException;
 
 use Exception;
 use ITB\ApiPlatformResourceActionsBundle\Exception\CompileTimeExceptionInterface;

--- a/src/Action/ResourceActionException/CommandNotAClassException.php
+++ b/src/Action/ResourceActionException/CommandNotAClassException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ITB\ApiPlatformResourceActionsBundle\Action\ActionException;
+namespace ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionException;
 
 use Exception;
 use ITB\ApiPlatformResourceActionsBundle\Exception\CompileTimeExceptionInterface;

--- a/src/Action/ResourceActionException/DescriptionBlankException.php
+++ b/src/Action/ResourceActionException/DescriptionBlankException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ITB\ApiPlatformResourceActionsBundle\Action\ActionException;
+namespace ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionException;
 
 use Exception;
 use ITB\ApiPlatformResourceActionsBundle\Exception\CompileTimeExceptionInterface;

--- a/src/Action/ResourceActionException/NameBlankException.php
+++ b/src/Action/ResourceActionException/NameBlankException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ITB\ApiPlatformResourceActionsBundle\Action\ActionException;
+namespace ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionException;
 
 use Exception;
 use ITB\ApiPlatformResourceActionsBundle\Exception\CompileTimeExceptionInterface;

--- a/src/Action/ResourceActionException/NoOperationConfiguredForActionException.php
+++ b/src/Action/ResourceActionException/NoOperationConfiguredForActionException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ITB\ApiPlatformResourceActionsBundle\Action\ActionException;
+namespace ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionException;
 
 use Exception;
 use ITB\ApiPlatformResourceActionsBundle\Exception\CompileTimeExceptionInterface;

--- a/src/Action/ResourceActionException/ResourceBlankException.php
+++ b/src/Action/ResourceActionException/ResourceBlankException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ITB\ApiPlatformResourceActionsBundle\Action\ActionException;
+namespace ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionException;
 
 use Exception;
 use ITB\ApiPlatformResourceActionsBundle\Exception\CompileTimeExceptionInterface;

--- a/src/Action/ResourceActionException/ResourceHasNoShortNameException.php
+++ b/src/Action/ResourceActionException/ResourceHasNoShortNameException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ITB\ApiPlatformResourceActionsBundle\Action\ActionException;
+namespace ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionException;
 
 use Exception;
 use ITB\ApiPlatformResourceActionsBundle\Exception\CompileTimeExceptionInterface;

--- a/src/Action/ResourceActionException/ResourceNotRegisteredException.php
+++ b/src/Action/ResourceActionException/ResourceNotRegisteredException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ITB\ApiPlatformResourceActionsBundle\Action\ActionException;
+namespace ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionException;
 
 use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
 use Exception;

--- a/src/Attribute/ResourceAction.php
+++ b/src/Attribute/ResourceAction.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ApiPlatformResourceActionsBundle\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final class ResourceAction
+{
+    /**
+     * @param string $actionName
+     * @param string $commandClass
+     * @param string|null $description
+     */
+    public function __construct(
+        public string $actionName,
+        public string $commandClass,
+        public ?string $description = null
+    ) {
+        // No further checks are performed here because the definition will always be used to create a ResourceAction.
+        // The ResourceAction is validated while constructed.
+    }
+}

--- a/src/Command/CommandFactory.php
+++ b/src/Command/CommandFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ITB\ApiPlatformResourceActionsBundle\Command;
 
-use ITB\ApiPlatformResourceActionsBundle\Action\ActionCollection;
+use ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionCollection;
 use ITB\ApiPlatformResourceActionsBundle\Command\CommandFactoryException\RequestResourceIsNullException;
 use ITB\ApiPlatformResourceActionsBundle\Exception\RuntimeExceptionInterface;
 use ITB\ApiPlatformResourceActionsBundle\Request\Request;
@@ -14,11 +14,11 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 final class CommandFactory
 {
     /**
-     * @param ActionCollection $actionCollection
+     * @param ResourceActionCollection $actionCollection
      * @param DenormalizerInterface $denormalizer
      */
     public function __construct(
-        private ActionCollection $actionCollection,
+        private ResourceActionCollection $actionCollection,
         private DenormalizerInterface $denormalizer
     ) {
     }

--- a/src/Definition/Collector/AttributeCollector.php
+++ b/src/Definition/Collector/AttributeCollector.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ApiPlatformResourceActionsBundle\Definition\Collector;
+
+use ITB\ApiPlatformResourceActionsBundle\Attribute\ResourceAction;
+use ITB\ApiPlatformResourceActionsBundle\Definition\ResourceActionDefinition;
+use ReflectionClass;
+
+final class AttributeCollector implements CollectorInterface
+{
+    /** @var ResourceActionDefinition[] $definitions */
+    private array $definitions = [];
+
+    public function __construct()
+    {
+        foreach (get_declared_classes() as $class) {
+            $reflection = new ReflectionClass($class);
+            foreach ($reflection->getAttributes(ResourceAction::class) as $reflectionAttribute) {
+                /** @var ResourceAction $resourceAction */
+                $resourceAction = $reflectionAttribute->newInstance();
+                $this->definitions[] = ResourceActionDefinition::fromResourceActionAttribute($resourceAction, $class);
+            }
+        }
+    }
+
+    /**
+     * @return ResourceActionDefinition[]
+     */
+    public function getResourceActionDefinitions(): array
+    {
+        return $this->definitions;
+    }
+}

--- a/src/Definition/Collector/CollectorInterface.php
+++ b/src/Definition/Collector/CollectorInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ApiPlatformResourceActionsBundle\Definition\Collector;
+
+use ITB\ApiPlatformResourceActionsBundle\Definition\ResourceActionDefinition;
+
+interface CollectorInterface
+{
+    /**
+     * @return ResourceActionDefinition[]
+     */
+    public function getResourceActionDefinitions(): array;
+}

--- a/src/Definition/Collector/ConfigurationCollector.php
+++ b/src/Definition/Collector/ConfigurationCollector.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ApiPlatformResourceActionsBundle\Definition\Collector;
+
+use ITB\ApiPlatformResourceActionsBundle\Definition\ResourceActionDefinition;
+
+final class ConfigurationCollector implements CollectorInterface
+{
+    /** @var ResourceActionDefinition[] $definitions */
+    private array $definitions = [];
+
+    /**
+     * @param array<string, array<string, array{
+     *     command_class: class-string,
+     *     description: string|null
+     * }>> $resourcesConfiguration
+     */
+    public function __construct(array $resourcesConfiguration)
+    {
+        foreach ($resourcesConfiguration as $resource => $actions) {
+            foreach ($actions as $action => $actionData) {
+                $this->definitions[] = new ResourceActionDefinition(
+                    $resource,
+                    $action,
+                    $actionData['command_class'],
+                    $actionData['description']
+                );
+            }
+        }
+    }
+
+    /**
+     * @return ResourceActionDefinition[]
+     */
+    public function getResourceActionDefinitions(): array
+    {
+        return $this->definitions;
+    }
+}

--- a/src/Definition/ResourceActionDefinition.php
+++ b/src/Definition/ResourceActionDefinition.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ApiPlatformResourceActionsBundle\Definition;
+
+use ITB\ApiPlatformResourceActionsBundle\Attribute\ResourceAction;
+
+final class ResourceActionDefinition
+{
+    /**
+     * @param string $resource
+     * @param string $action
+     * @param string $command
+     * @param string|null $description
+     */
+    public function __construct(
+        public string $resource,
+        public string $action,
+        public string $command,
+        public ?string $description
+    ) {
+        // No further checks are performed here because the definition will always be used to create a ResourceAction.
+        // The ResourceAction is validated while constructed.
+    }
+
+    /**
+     * @param ResourceAction $resourceAction
+     * @param string $resourceClass
+     * @return ResourceActionDefinition
+     */
+    public static function fromResourceActionAttribute(
+        ResourceAction $resourceAction,
+        string $resourceClass
+    ): ResourceActionDefinition {
+        return new self(
+            $resourceClass,
+            $resourceAction->actionName,
+            $resourceAction->commandClass,
+            $resourceAction->description
+        );
+    }
+}

--- a/src/Definition/ResourceActionDefinitionCollection.php
+++ b/src/Definition/ResourceActionDefinitionCollection.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ApiPlatformResourceActionsBundle\Definition;
+
+use ITB\ApiPlatformResourceActionsBundle\Definition\Collector\AttributeCollector;
+use ITB\ApiPlatformResourceActionsBundle\Definition\Collector\CollectorInterface;
+use ITB\ApiPlatformResourceActionsBundle\Definition\Collector\ConfigurationCollector;
+use ITB\ApiPlatformResourceActionsBundle\Definition\ResourceActionDefinitionCollectionException\ResourceActionNotUniqueException;
+use ITB\ApiPlatformResourceActionsBundle\Exception\CompileTimeExceptionInterface;
+
+final class ResourceActionDefinitionCollection
+{
+    /** @var CollectorInterface[] */
+    private array $collectors = [];
+
+    /**
+     * @param array<string, array<string, array{
+     *     command_class: class-string,
+     *     description: string|null
+     * }>> $resourcesConfiguration
+     */
+    public function __construct(array $resourcesConfiguration)
+    {
+        $this->collectors[] = new ConfigurationCollector($resourcesConfiguration);
+        $this->collectors[] = new AttributeCollector();
+    }
+
+    /**
+     * @return ResourceActionDefinition[]
+     * @throws CompileTimeExceptionInterface
+     */
+    public function getResourceActionDefinitions(): array
+    {
+        $definitions = [];
+        // The map is used to check if an action already exists.
+        $resourceActionMap = [];
+
+        foreach ($this->collectors as $collector) {
+            foreach ($collector->getResourceActionDefinitions() as $resourceActionDefinition) {
+                // Check if the action for the resource is already in the map. The combination has to be unique.
+                if (
+                    array_key_exists($resourceActionDefinition->resource, $resourceActionMap) && in_array(
+                        $resourceActionDefinition->action,
+                        $resourceActionMap[$resourceActionDefinition->resource]
+                    )
+                ) {
+                    throw ResourceActionNotUniqueException::create(
+                        $resourceActionDefinition->resource,
+                        $resourceActionDefinition->action
+                    );
+                }
+
+                $definitions[] = $resourceActionDefinition;
+                // The definition's resource (as map key) and action (as array element) are added to the map to allow checking for uniqueness.
+                $resourceActionMap[$resourceActionDefinition->resource] = array_merge(
+                    $resourceActionMap[$resourceActionDefinition->resource] ?? [],
+                    [$resourceActionDefinition->action]
+                );
+            }
+        }
+
+        return $definitions;
+    }
+}

--- a/src/Definition/ResourceActionDefinitionCollectionException/ResourceActionNotUniqueException.php
+++ b/src/Definition/ResourceActionDefinitionCollectionException/ResourceActionNotUniqueException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ApiPlatformResourceActionsBundle\Definition\ResourceActionDefinitionCollectionException;
+
+use Exception;
+use ITB\ApiPlatformResourceActionsBundle\Exception\CompileTimeExceptionInterface;
+
+final class ResourceActionNotUniqueException extends Exception implements CompileTimeExceptionInterface
+{
+    /**
+     * @param string $resource
+     * @param string $action
+     * @return ResourceActionNotUniqueException
+     */
+    public static function create(string $resource, string $action): ResourceActionNotUniqueException
+    {
+        return new self(
+            sprintf('The action "%s" is defined at least twice for the resource "%s".', $action, $resource)
+        );
+    }
+}

--- a/src/DependencyInjection/ITBApiPlatformResourceActionsExtension.php
+++ b/src/DependencyInjection/ITBApiPlatformResourceActionsExtension.php
@@ -36,19 +36,8 @@ final class ITBApiPlatformResourceActionsExtension extends Extension
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
-        $actionsData = [];
-        foreach ($config['resources'] as $resource => $actions) {
-            foreach ($actions as $action => $actionData) {
-                $actionsData[] = [
-                    'resource' => $resource,
-                    'action' => $action,
-                    'commandClass' => $actionData['command_class'],
-                    'description' => $actionData['description']
-                ];
-            }
-        }
-        $actionCollection = $container->getDefinition('itb_api_platform_resource_actions.action_collection');
-        $actionCollection->replaceArgument(0, $actionsData);
+        $resourceActionDefinitionCollection = $container->getDefinition('itb_api_platform_resource_actions.resource_action_definition_collection');
+        $resourceActionDefinitionCollection->replaceArgument(0, $config['resources']);
 
         $controller = $container->getDefinition('itb_api_platform_resource_actions.controller');
         $controller->replaceArgument(3, $config['validate_command']);

--- a/src/Docs/OpenApiFactory.php
+++ b/src/Docs/OpenApiFactory.php
@@ -9,8 +9,8 @@ use ApiPlatform\Core\OpenApi\Factory\OpenApiFactoryInterface;
 use ApiPlatform\Core\OpenApi\OpenApi;
 use ApiPlatform\Core\PathResolver\OperationPathResolverInterface;
 use Console_Table;
-use ITB\ApiPlatformResourceActionsBundle\Action\ActionCollection;
-use ITB\ApiPlatformResourceActionsBundle\Action\ActionCommandMetadata;
+use ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionCollection;
+use ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionCommandMetadata;
 use ITB\ApiPlatformResourceActionsBundle\Docs\OpenApiFactoryException\PathNotfoundException;
 use ITB\ApiPlatformResourceActionsBundle\Exception\CompileTimeExceptionInterface;
 
@@ -18,12 +18,12 @@ final class OpenApiFactory implements OpenApiFactoryInterface
 {
     /**
      * @param OpenApiFactoryInterface $decorated
-     * @param ActionCollection $actionCollection
+     * @param ResourceActionCollection $actionCollection
      * @param OperationPathResolverInterface $operationPathResolver
      */
     public function __construct(
         private OpenApiFactoryInterface $decorated,
-        private ActionCollection $actionCollection,
+        private ResourceActionCollection $actionCollection,
         private OperationPathResolverInterface $operationPathResolver
     ) {
     }
@@ -102,11 +102,11 @@ final class OpenApiFactory implements OpenApiFactoryInterface
     }
 
     /**
-     * @param ActionCommandMetadata $commandMetadata
+     * @param ResourceActionCommandMetadata $commandMetadata
      * @param string $resource
      * @return string
      */
-    private function getPayloadProperties(ActionCommandMetadata $commandMetadata, string $resource): string
+    private function getPayloadProperties(ResourceActionCommandMetadata $commandMetadata, string $resource): string
     {
         $properties = '';
         foreach ($commandMetadata->getConstructorParameters() as $parameter) {

--- a/src/Request/RequestTransformer.php
+++ b/src/Request/RequestTransformer.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace ITB\ApiPlatformResourceActionsBundle\Request;
 
 use ApiPlatform\Core\DataTransformer\DataTransformerInterface;
-use ITB\ApiPlatformResourceActionsBundle\Action\ActionCollection;
+use ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionCollection;
 use ITB\ApiPlatformResourceActionsBundle\Context\ApiPlatformContext;
 use ITB\ApiPlatformResourceActionsBundle\Exception\RuntimeExceptionInterface;
 
 final class RequestTransformer implements DataTransformerInterface
 {
     /**
-     * @param ActionCollection $actionCollection
+     * @param ResourceActionCollection $actionCollection
      */
-    public function __construct(private ActionCollection $actionCollection)
+    public function __construct(private ResourceActionCollection $actionCollection)
     {
     }
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -5,8 +5,11 @@
         https://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="itb_api_platform_resource_actions.action_collection" class="ITB\ApiPlatformResourceActionsBundle\Action\ActionCollection">
+        <service id="itb_api_platform_resource_actions.resource_action_definition_collection" class="ITB\ApiPlatformResourceActionsBundle\Definition\ResourceActionDefinitionCollection">
             <argument/> <!-- filled in via configuration -->
+        </service>
+        <service id="itb_api_platform_resource_actions.action_collection" class="ITB\ApiPlatformResourceActionsBundle\Action\ActionCollection">
+            <argument type="service" id="itb_api_platform_resource_actions.resource_action_definition_collection"/>
             <argument type="service" id="api_platform.metadata.resource.metadata_factory"/>
         </service>
         <service id="itb_api_platform_resource_actions.command_factory" class="ITB\ApiPlatformResourceActionsBundle\Command\CommandFactory" public="false">

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -8,16 +8,16 @@
         <service id="itb_api_platform_resource_actions.resource_action_definition_collection" class="ITB\ApiPlatformResourceActionsBundle\Definition\ResourceActionDefinitionCollection">
             <argument/> <!-- filled in via configuration -->
         </service>
-        <service id="itb_api_platform_resource_actions.action_collection" class="ITB\ApiPlatformResourceActionsBundle\Action\ActionCollection">
+        <service id="itb_api_platform_resource_actions.resource_action_collection" class="ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionCollection">
             <argument type="service" id="itb_api_platform_resource_actions.resource_action_definition_collection"/>
             <argument type="service" id="api_platform.metadata.resource.metadata_factory"/>
         </service>
         <service id="itb_api_platform_resource_actions.command_factory" class="ITB\ApiPlatformResourceActionsBundle\Command\CommandFactory" public="false">
-            <argument type="service" id="itb_api_platform_resource_actions.action_collection"/>
+            <argument type="service" id="itb_api_platform_resource_actions.resource_action_collection"/>
             <argument type="service" id="serializer"/>
         </service>
         <service id="itb_api_platform_resource_actions.request_transformer" class="ITB\ApiPlatformResourceActionsBundle\Request\RequestTransformer">
-            <argument type="service" id="itb_api_platform_resource_actions.action_collection"/>
+            <argument type="service" id="itb_api_platform_resource_actions.resource_action_collection"/>
             <tag>api_platform.data_transformer</tag>
         </service>
         <service id="itb_api_platform_resource_actions.controller" class="ITB\ApiPlatformResourceActionsBundle\Controller\Controller" public="false">
@@ -36,7 +36,7 @@
 
         <service id="itb_api_platform_resource_actions.open_api_factory" decorates="api_platform.openapi.factory" class="ITB\ApiPlatformResourceActionsBundle\Docs\OpenApiFactory">
             <argument type="service" id=".inner"/>
-            <argument type="service" id="itb_api_platform_resource_actions.action_collection"/>
+            <argument type="service" id="itb_api_platform_resource_actions.resource_action_collection"/>
             <argument type="service" id="api_platform.operation_path_resolver"/>
         </service>
         <service alias="itb_api_platform_resource_actions.open_api_factory" id="ApiPlatform\Core\OpenApi\Factory\OpenApiFactoryInterface"/>

--- a/src/Validation/ActionRequestValidator.php
+++ b/src/Validation/ActionRequestValidator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ITB\ApiPlatformResourceActionsBundle\Validation;
 
-use ITB\ApiPlatformResourceActionsBundle\Action\ActionCollectionException\ActionForResourceNotFound;
+use ITB\ApiPlatformResourceActionsBundle\Action\ResourceActionCollectionException\ActionForResourceNotFound;
 use ITB\ApiPlatformResourceActionsBundle\Command\CommandFactory;
 use ITB\ApiPlatformResourceActionsBundle\Exception\RuntimeExceptionInterface;
 use ITB\ApiPlatformResourceActionsBundle\Request\Request;


### PR DESCRIPTION
The definition system is reworked to allow multiple sources. Currently actions can be defined via bundle configuration (YAML, XML, PHP) and via PHP class attributes (annotations were not implemented because PHP 8.0 is required).